### PR TITLE
Only wait for tasks to complete if the workers exit code is 0

### DIFF
--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -315,7 +315,6 @@ class ParallelRunner(object):
 
         [p.join() for p in processes]
 
-        queue.join()
         wait_for_responses_processor()
 
         if not errors.empty():


### PR DESCRIPTION
pytest-parallel waits for all tasks that have been picked up by workers to be marked as completed. However, workers may have been killed (e.g., in the case of a timeout), and thus failed to mark the tasks as completed. In this case, the main thread would wait undefinitely.

We use the workers exitcode to determine if a failure occurred. In such a case, we do not wait to all tasks to complete.