### PR TITLE
Unregister terminalreporter in workers

### DIFF
--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -62,6 +62,10 @@ def process_with_threads(config, queue, session, tests_per_worker, errors):
     # so we know we are running as a worker.
     config.parallel_worker = True
 
+    # Unregister "terminalreporter" to prevent the workers from outputting
+    # anything. The main thread is in charge of that.
+    config.pluginmanager.unregister(name="terminalreporter")
+
     if tests_per_worker == 1:
         worker_run(current_process().name, queue, session, errors)
     else:
@@ -201,12 +205,6 @@ class ParallelRunner(object):
         self._config = config
         self._manager = Manager()
         self._log = py.log.Producer('pytest-parallel')
-
-        reporter = config.pluginmanager.getplugin('terminalreporter')
-
-        # prevent mangling the output
-        reporter.showfspath = False
-        reporter._show_progress_info = False
 
         # get the number of workers
         workers = parse_config(config, 'workers')


### PR DESCRIPTION
The forked workers run pytest_runtest_protocol, which in turn runs the followinng hooks:
- pytest_runtest_logstart
- pytest_runtest_logreport
- pytest_runtest_logfinish Built-in "terminalreporter" plugin hooks to all of the above to print the progress of the test suite (printing each completed tests and other info such as the test-suite completion percentage). This results in interleaved output, as well as duplicating the output printed by the main thread which is also running pytest_runtest_logreport.

We thus unregister terminalreporter in the workers before running any test, leaving main in charge of reporting test results.