### PR TITLE
Override workers when number of tests to execute is less

### DIFF
--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -246,6 +246,13 @@ class ParallelRunner(object):
 
         if session.config.option.collectonly:
             return True
+        
+        # Override the number of workers based on the number of tests being
+        # executed if it is less than what was originally configured. This
+        # is a speculative fix to avoid pytest from hanging when more workers
+        # are spawned than is needed by the number of tests being executed.
+        if self.workers > len(session.items):
+            self.workers = len(session.items)
 
         # get the number of tests per worker
         tests_per_worker = parse_config(session.config, 'tests_per_worker')


### PR DESCRIPTION
A number of pytest sessions are hanging at the end and it is not 100% clear what the cause is. However, some experimentation with the number of workers and tests to execute has shown:

  - When they exceed the number of tests to execute, the hang at the end of the pytest session is more likely to occur
  - When they are equal to or less than the tests to execute, the hang has yet to occur

Therefore, this speculative fix overrides the `workers` to be the number of tests to execute when it exceeds the originally configured number.