### PR TITLE
Set TerminalWriter instance in workers outputs to /dev/null

### DIFF
--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -62,19 +62,21 @@ def process_with_threads(config, queue, session, tests_per_worker, errors):
     # so we know we are running as a worker.
     config.parallel_worker = True
 
-    # Unregister "terminalreporter" to prevent the workers from outputting
-    # anything. The main thread is in charge of that.
-    config.pluginmanager.unregister(name="terminalreporter")
+    with open(os.devnull, "w") as devnull:
+        # Replace the TerminalWriter of terminalreporter with one that outputs
+        # to /dev/null.
+        reporter = config.pluginmanager.get_plugin("terminalreporter")
+        reporter._tw = _pytest.config.create_terminal_writer(config, devnull)
 
-    if tests_per_worker == 1:
-        worker_run(current_process().name, queue, session, errors)
-    else:
-        threads = []
-        for _ in range(tests_per_worker):
-            thread = ThreadWorker(queue, session, errors)
-            thread.start()
-            threads.append(thread)
-        [t.join() for t in threads]
+        if tests_per_worker == 1:
+            worker_run(current_process().name, queue, session, errors)
+        else:
+            threads = []
+            for _ in range(tests_per_worker):
+                thread = ThreadWorker(queue, session, errors)
+                thread.start()
+                threads.append(thread)
+            [t.join() for t in threads]
 
 
 def worker_run(name, queue, session, errors):


### PR DESCRIPTION
In commit 76bcb8f "Unregister terminalreporter in workers", we unregister terminalreporter plugin in the workers to avoid duplicated prints.

However, since pytest.git commit fbe3e29 "Color the full diff that pytest shows as a diff", `assertrepr_compare` method now consume terminalreporter to inject the characters that control text colour and highlighting. Before the commit, pytest seems to have tolerated a missing terminalreporter which is not the case anymore.

In this patch, we solve the issue by taking an alternative approach to fix the duplicated prints. Instead of unregistering the plugin, we sneakily replace the TerminalWriter instance of the plugin, using one that writes to /dev/null instead of stdout. There are probably more elegant ways to address the issue, but at the origin of the problem there is pytest making use of the same class private field we are overwriting. Furthermore, there are plans to make changes around TerminalWriter (https://github.com/pytest-dev/pytest/issues/10436), so any heavyweight solution seems to be a potential waste of time.