### PR TITLE
Propagate PYTEST_CURRENT_TEST when tests spawn their own threads

### DIFF
--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -23,6 +23,9 @@ if sys.platform.startswith('darwin'):
 
 __version__ = '0.1.1'
 
+# We monkey-patch the standard library to make these environment variables thread-local.
+THREAD_LOCAL_ENV_VARS = ["PYTEST_CURRENT_TEST"]
+
 
 def parse_config(config, name):
     return getattr(config.option, name, config.getini(name))
@@ -152,7 +155,7 @@ class ThreadLocalEnviron(os._Environ):
             self.thread_store = threading.local()
 
     def __getitem__(self, key):
-        if key == 'PYTEST_CURRENT_TEST':
+        if key in THREAD_LOCAL_ENV_VARS:
             if hasattr(self.thread_store, key):
                 value = getattr(self.thread_store, key)
                 return self.decodevalue(value)
@@ -161,7 +164,7 @@ class ThreadLocalEnviron(os._Environ):
         return super().__getitem__(key)
 
     def __setitem__(self, key, value):
-        if key == 'PYTEST_CURRENT_TEST':
+        if key in THREAD_LOCAL_ENV_VARS:
             value = self.encodevalue(value)
             self.putenv(self.encodekey(key), value)
             setattr(self.thread_store, key, value)
@@ -169,7 +172,7 @@ class ThreadLocalEnviron(os._Environ):
             super().__setitem__(key, value)
 
     def __delitem__(self, key):
-        if key == 'PYTEST_CURRENT_TEST':
+        if key in THREAD_LOCAL_ENV_VARS:
             self.unsetenv(self.encodekey(key))
             if hasattr(self.thread_store, key):
                 delattr(self.thread_store, key)
@@ -179,8 +182,9 @@ class ThreadLocalEnviron(os._Environ):
             super().__delitem__(key)
 
     def __iter__(self):
-        if hasattr(self.thread_store, 'PYTEST_CURRENT_TEST'):
-            yield 'PYTEST_CURRENT_TEST'
+        for key in THREAD_LOCAL_ENV_VARS:
+            if hasattr(self.thread_store, key):
+                yield key
         keys = list(self._data)
         for key in keys:
             yield self.decodekey(key)

--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -196,6 +196,30 @@ class ThreadLocalEnviron(os._Environ):
         return type(self)(self)
 
 
+class EnvironPropagatingThread(threading.Thread):
+    def start(self):
+        # Things we put in thread-local storage will fail to propagate to child
+        # threads, so do that manually here.
+        saved = {}
+        for key in THREAD_LOCAL_ENV_VARS:
+            if key in os.environ:
+                saved[key] = os.environ[key]
+
+        # Python (currently) specifies that start() can only be called once, but
+        # let's avoid recursively wrapping the original run() anyway.
+        if not hasattr(self, '__original_run'):
+            self.__original_run = self.run
+
+        def run():
+            for key, value in saved.items():
+                os.environ[key] = value
+            self.__original_run()
+
+        self.run = run
+
+        super().start()
+
+
 class ThreadLocalSetupState(threading.local, _pytest.runner.SetupState):
     def __init__(self):
         super(ThreadLocalSetupState, self).__init__()
@@ -240,6 +264,9 @@ class ParallelRunner(object):
         # make the environment threadsafe
         os.environ = ThreadLocalEnviron(os.environ)
 
+        # ...but don't break environment propagation to any threads spawned by the tests themselves.
+        threading.Thread = EnvironPropagatingThread
+
     def pytest_runtestloop(self, session):
         if (
             session.testsfailed
@@ -252,7 +279,7 @@ class ParallelRunner(object):
 
         if session.config.option.collectonly:
             return True
-        
+
         # Override the number of workers based on the number of tests being
         # executed if it is less than what was originally configured. This
         # is a speculative fix to avoid pytest from hanging when more workers


### PR DESCRIPTION
Since we were using PYTEST_CURRENT_TEST in our logging filters, we were losing all logs from threads that tests spawn. This fixes that; see the individual commits.