### PR TITLE
Add hook to control when workers stop picking up new tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,48 @@ pytest --tests-per-worker auto
 pytest --workers 2 --tests-per-worker auto
 ```
 
+## Stopping a parallel run early
+
+`pytest-parallel` exposes a hook that lets other plugins or `conftest.py` tell
+workers to stop picking up new tests:
+
+```python
+@pytest.hookspec(firstresult=True)
+def pytest_parallel_should_stop(session):
+    """Return True to stop workers from picking up new tests."""
+```
+
+Each worker polls the hook:
+
+* after every test completes, and
+* whenever the test queue is idle.
+
+The first registered implementation that returns a non-`None` value wins.
+Return `True` to stop, `False` to keep running, or `None` to defer to other
+implementations. If no implementation is registered, or if every implementation
+returns `None`, workers keep running as usual.
+
+### Example hook implementation
+
+```python
+def pytest_parallel_should_stop(session):
+    if session_should_be_aborted(session):
+        return True
+    return None  # let other implementations decide
+```
+
+### Caveats
+
+- Each worker runs in its own subprocess with its own copy of `session`.
+  Implementations should rely on state visible from inside a worker process:
+  shared `multiprocessing` primitives, files on disk, or the worker-local
+  `session` state that pytest mutates in response to per-test reports.
+* `pytest-parallel` does **not** observe pytest's built-in `session.shouldstop`
+  or `session.shouldfail` flags across workers. There is currently no channel
+  to propagate those signals from the master to the workers, so flags set by
+  features like `--maxfail` are not enforced across workers. Plugins that want
+  cross-worker stop semantics must implement this hook themselves.
+
 ## Notice
 
 Beginning with Python 3.8, forking behavior is forced on macOS at the expense of safety.

--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -8,8 +8,11 @@ import _pytest
 import platform
 import threading
 import multiprocessing
+import queue as queue_module
 from tblib import pickling_support
 from multiprocessing import current_process, Manager, Process
+
+from . import hookspec as _parallel_hookspec
 
 # In Python 3.8 and later, the default on macOS is spawn.
 # We force forking behavior at the expense of safety.
@@ -25,6 +28,18 @@ __version__ = '0.1.1'
 
 # We monkey-patch the standard library to make these environment variables thread-local.
 THREAD_LOCAL_ENV_VARS = ["PYTEST_CURRENT_TEST"]
+
+# How long a worker blocks on the test queue before re-checking the
+# pytest_parallel_should_stop hook. Kept small so callers get a responsive
+# shutdown, but not so small that idle workers eat CPU.
+WORKER_POLL_INTERVAL_SEC = 0.1
+
+
+def pytest_addhooks(pluginmanager):
+    """
+    Register pytest-parallel's own hook specifications.
+    """
+    pluginmanager.add_hookspecs(_parallel_hookspec)
 
 
 def parse_config(config, name):
@@ -82,17 +97,38 @@ def process_with_threads(config, queue, session, tests_per_worker, errors):
             [t.join() for t in threads]
 
 
+def _should_stop(session):
+    """
+    Invoke the `pytest_parallel_should_stop` hook, swallowing errors.
+
+    A misbehaving hook implementation should not be able to take down a
+    worker, so any exception is treated effectively as "don't stop".
+    """
+    try:
+        return bool(
+            session.config.hook.pytest_parallel_should_stop(session=session)
+        )
+    except BaseException:
+        return False
+
+
 def worker_run(name, queue, session, errors):
     pickling_support.install()
     while True:
         try:
-            index = queue.get()
-            if index == 'stop':
-                queue.task_done()
+            index = queue.get(timeout=WORKER_POLL_INTERVAL_SEC)
+        except queue_module.Empty:
+            # No work available right now. Give other plugins a chance to
+            # cancel the run, then keep polling.
+            if _should_stop(session):
                 break
-        except ConnectionRefusedError:
-            time.sleep(.1)
             continue
+        except ConnectionRefusedError:
+            time.sleep(WORKER_POLL_INTERVAL_SEC)
+            continue
+        if index == 'stop':
+            queue.task_done()
+            break
         item = session.items[index]
         try:
             run_test(session, item, None)
@@ -106,6 +142,12 @@ def worker_run(name, queue, session, errors):
                 queue.task_done()
             except ConnectionRefusedError:
                 pass
+        # Stop check is outside the `finally` block on purpose: PEP 765 flags
+        # `break` inside `finally` because it silently suppresses any in-flight
+        # exception. Running this check after the finally completes keeps the
+        # normal shutdown path and lets real exceptions propagate unchanged.
+        if _should_stop(session):
+            break
 
 
 class ThreadWorker(threading.Thread):

--- a/pytest_parallel/hookspec.py
+++ b/pytest_parallel/hookspec.py
@@ -1,0 +1,32 @@
+import pytest
+
+
+@pytest.hookspec(firstresult=True)
+def pytest_parallel_should_stop(session):
+    """
+    Return True to stop pytest-parallel workers from picking up new tests.
+
+    This hook offers control over when other plugins (or `conftest.py`) can
+    abort a parallel pytest session. It is called by each worker:
+
+        - After every test finishes, and
+        - Whenever a worker's test queue is idle.
+
+    It uses `firstresult=True` semantics: the first registered implementation
+    that returns a non-`None` value wins. Return `True` to stop, `False`
+    to keep running, or `None` to defer to other implementations. If no
+    implementation returns a non-`None` value, workers keep running as
+    usual.
+
+    This plugin does not register its own default implementation. This means
+    that pytest's built-in `session.shouldstop` or `session.shouldfail` signals
+    (set by features like `--maxfail`) are **not** observed across workers:
+    each worker runs in its own subprocess with its own `session`, and there is
+    currently no channel to propagate those signals from the master to the
+    workers. Plugins that want cross-worker stop semantics must implement this
+    hook themselves, typically by sharing state through `multiprocessing`
+    primitives or files on disk.
+
+    Each worker sees its own copy of `session`, so implementations should
+    rely on state that is visible from within a worker process.
+    """

--- a/tests/test_should_stop_hook.py
+++ b/tests/test_should_stop_hook.py
@@ -1,0 +1,69 @@
+def test_custom_should_stop_hook_halts_workers(testdir):
+    """
+    Test that a registered implementation of `pytest_parallel_should_stop`
+    that returns `True` causes the workers to stop before running every test.
+
+    The conftest writes a sentinel file after the first test completes and
+    then returns True from the hook; remaining tests must not run.
+    """
+    testdir.makepyfile(conftest="""
+        import os
+
+        SENTINEL = os.path.join(os.path.dirname(__file__), 'stop.sentinel')
+
+        def pytest_runtest_logreport(report):
+            if report.when == 'call':
+                open(SENTINEL, 'a').close()
+
+        def pytest_parallel_should_stop(session):
+            return os.path.exists(SENTINEL)
+    """)
+    testdir.makepyfile("""
+        def test_1(): pass
+        def test_2(): pass
+        def test_3(): pass
+        def test_4(): pass
+        def test_5(): pass
+    """)
+    result = testdir.runpytest('--workers=1')
+    result.assert_outcomes(passed=1)
+    assert result.ret == 0
+
+
+def test_should_stop_hook_false_keeps_running(testdir):
+    """
+    Test that an implementation that always returns `False` must not interfere
+    with a normal run; every test should still execute.
+    """
+    testdir.makepyfile(conftest="""
+        def pytest_parallel_should_stop(session):
+            return False
+    """)
+    testdir.makepyfile("""
+        def test_1(): pass
+        def test_2(): pass
+        def test_3(): pass
+    """)
+    result = testdir.runpytest('--workers=1')
+    result.assert_outcomes(passed=3)
+    assert result.ret == 0
+
+
+def test_should_stop_hook_none_is_neutral(testdir):
+    """
+    Test that returning `None` from an implementation is neutral: it does not
+    stop the workers, and it does not itself cause a failure. With no other
+    implementation registered, workers run every collected test to completion.
+    """
+    testdir.makepyfile(conftest="""
+        def pytest_parallel_should_stop(session):
+            return None
+    """)
+    testdir.makepyfile("""
+        def test_1(): pass
+        def test_2(): pass
+        def test_3(): pass
+    """)
+    result = testdir.runpytest('--workers=1')
+    result.assert_outcomes(passed=3)
+    assert result.ret == 0


### PR DESCRIPTION
There is a need to abort the `pytest` session early if a threshold of failures is reached. While this is straight forward to implement when running tests serially, it is more complex when running tests in parallel.

To help simplify this, this commit extends the `pytest-parallel` plugin with a new hook that allows other plugins to control when workers stop picking up new tests. This is achieved by adding a new hookspec to the plugin, which expects to return the following values:

  - `True` to stop the worker from picking up new tests
  - `False` to keep the worker running and pick up new tests
  - `None` to defer to the default implementation, which is to stop the worker if pytest's own `session.shouldstop` or `session.shouldfail` is set.

The hook is then invoked by each worker after every test finishes and whenever the worker's test queue is idle. The first registered implementation that returns a non-`None` value wins.

The default implementation is to stop the worker if pytest's own `session.shouldstop` or `session.shouldfail` is set. This is the same behaviour as the existing `pytest-xdist` plugin, and ensures that features like `--maxfail` work in parallel mode without any extra wiring.

This commit also adds a new test suite to the project to verify the new hook and its default implementation.