### PR TITLE
Respect session shouldstop and shouldfail across parallel workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,30 @@ pytest --tests-per-worker auto
 pytest --workers 2 --tests-per-worker auto
 ```
 
+## Early stopping
+
+This plugin honours the built-in session-stop flags supported by `pytest`
+(`session.shouldstop` and `session.shouldfail`) even when tests are running
+across multiple worker processes. The master process observes these flags after
+each worker test report is dispatched; once either flag is set, the remaining
+backlog is drained from the shared test queue so idle workers exit cleanly.
+Tests that were already running when the stop fires are allowed to finish,
+matching pytest's normal "interrupt" semantics.
+
+In practice, this means `--maxfail` works across workers. Note that slightly
+more tests than `--maxfail` specifies may still run: tests already executing
+when the stop fires are allowed to finish, and a small window exists between
+when pytest sets the stop flag and when the master drains the queue in which
+idle workers can still pick up pending tests.
+
+```bash
+# stop after the first failure, regardless of how many workers are running
+pytest --workers=4 --maxfail=1
+```
+
+Any other plugin or hook that sets `session.shouldstop` or
+`session.shouldfail` on the master session will trigger the same behaviour.
+
 ## Notice
 
 Beginning with Python 3.8, forking behavior is forced on macOS at the expense of safety.

--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -8,6 +8,7 @@ import _pytest
 import platform
 import threading
 import multiprocessing
+import queue as queue_module
 from tblib import pickling_support
 from multiprocessing import current_process, Manager, Process
 
@@ -25,6 +26,9 @@ __version__ = '0.1.1'
 
 # We monkey-patch the standard library to make these environment variables thread-local.
 THREAD_LOCAL_ENV_VARS = ["PYTEST_CURRENT_TEST"]
+
+# Sentinel value for stopping the worker.
+STOP_SENTINEL = 'stop'
 
 
 def parse_config(config, name):
@@ -59,6 +63,49 @@ def run_test(session, item, nextitem):
         raise session.Interrupted(session.shouldstop)
 
 
+def _drain_test_queue(queue):
+    """
+    Drain pending test indices from `queue`, preserving 'stop' sentinels.
+
+    Used by master when pytest has decided the session should stop (e.g.
+    `--maxfail` has been tripped) so that workers still blocked on
+    `queue.get()` will next receive a sentinel and exit cleanly. Any tests
+    already in-flight in a worker will run to completion; only the untouched
+    backlog is discarded.
+
+    :param queue: The queue to drain.
+    :return: The number of test indices that were dropped.
+    """
+    dropped = 0
+    stashed_sentinels = 0
+    while True:
+        try:
+            item = queue.get_nowait()
+        except queue_module.Empty:
+            break
+        except ConnectionRefusedError:
+            break
+
+        if item == STOP_SENTINEL:
+            stashed_sentinels += 1
+        else:
+            dropped += 1
+        try:
+            queue.task_done()
+        except ConnectionRefusedError:
+            pass
+
+    # Put the sentinels back so workers that are still blocked on `get()` will
+    # see one and exit. Workers that are already past `get()` (running a test)
+    # will pick a sentinel up on their next iteration.
+    for _ in range(stashed_sentinels):
+        try:
+            queue.put(STOP_SENTINEL)
+        except ConnectionRefusedError:
+            pass
+    return dropped
+
+
 def process_with_threads(config, queue, session, tests_per_worker, errors):
     # This function will be called from subprocesses, forked from the main
     # pytest process. First thing we need to do is to change config's value
@@ -87,7 +134,7 @@ def worker_run(name, queue, session, errors):
     while True:
         try:
             index = queue.get()
-            if index == 'stop':
+            if index == STOP_SENTINEL:
                 queue.task_done()
                 break
         except ConnectionRefusedError:
@@ -236,6 +283,11 @@ class ParallelRunner(object):
         self._manager = Manager()
         self._log = py.log.Producer('pytest-parallel')
 
+        # Populated in pytest_runtestloop once the session and queue are known.
+        self._session = None
+        self._queue = None
+        self._stop_requested = False
+
         # get the number of workers
         workers = parse_config(config, 'workers')
         try:
@@ -320,6 +372,12 @@ class ParallelRunner(object):
         queue = queue_cls()
         errors = queue_cls()
 
+        # Stashed for the response processor so it can drain the test queue
+        # when pytest signals `session.shouldstop` or `session.shouldfail`.
+        self._session = session
+        self._queue = queue
+        self._stop_requested = False
+
         # Reports about tests will be gathered from workerss
         # using this queue. Workers will push reports to the queue,
         # and a separate thread will rerun pytest_runtest_logreport
@@ -333,7 +391,7 @@ class ParallelRunner(object):
         # Now we need to put stopping sentinels, so that worker
         # processes will know, there is time to finish the work.
         for i in range(self.workers * tests_per_worker):
-            queue.put('stop')
+            queue.put(STOP_SENTINEL)
 
         processes = []
 
@@ -396,6 +454,37 @@ class ParallelRunner(object):
             config=self._config, data=report
         )
         self._config.hook.pytest_runtest_logreport(report=report)
+
+        # pytest mutates `session.shouldstop` or `session.shouldfail` during
+        # its own `pytest_runtest_logreport` handler (for example when
+        # `--maxfail` is tripped). Check immediately so that workers stop
+        # pulling from the queue as soon as pytest decides the session should
+        # stop.
+        self._check_for_stop()
+
+    def _check_for_stop(self):
+        """
+        Drain the remaining backlog if the master session wants to stop.
+
+        This is called from the response-processing thread after each test
+        report is dispatched. Repeated calls after the first successful drain
+        are no-ops.
+        """
+        if self._stop_requested:
+            return
+        session = self._session
+        if session is None:
+            return
+        if not (session.shouldstop or session.shouldfail):
+            return
+        self._stop_requested = True
+        reason = session.shouldstop or session.shouldfail
+        dropped = _drain_test_queue(self._queue)
+        if dropped:
+            self._log(
+                f"pytest-parallel: stopping early ({reason}); "
+                f"{dropped} pending test(s) will not be run"
+            )
 
     def process_responses(self, queue):
         while True:

--- a/tests/test_early_stop.py
+++ b/tests/test_early_stop.py
@@ -1,0 +1,115 @@
+"""
+Tests covering pytest-parallel"s master-side early-stop behaviour.
+
+The plugin observes the master session"s `shouldstop` and `shouldfail` flags
+after each worker test report is dispatched. When either flag is set (for
+example because `--maxfail` has been tripped) the plugin drains the shared test
+queue so that idle workers exit via their existing "stop" sentinel. Tests
+already running in a worker are allowed to finish, matching pytest"s normal
+`--maxfail` semantics.
+"""
+
+import pytest
+
+
+def _create_test_module_content(num_tests, tests_pass=False):
+    """
+    Create the contents of a test module where every test either passes or
+    fails after a short sleep.
+
+    The sleep is important: it makes the scheduling deterministic enough that
+    workers cannot race through the entire backlog before the master has a
+    chance to dispatch a log report and drain the queue.
+
+    :param num_tests: The number of tests to create.
+    :param tests_pass: Whether the tests should pass or fail.
+    :return: The contents of a test module.
+    """
+    test_functions = "\n\n".join(
+        f"def test_{i}():\n    time.sleep(0.05)\n    assert {tests_pass}"
+        for i in range(num_tests)
+    )
+    return f"""
+import time
+
+{test_functions}
+"""
+
+
+@pytest.mark.parametrize(
+    "cli_args",
+    [
+        ["--workers=2"],
+        ["--tests-per-worker=2"],
+        ["--workers=2", "--tests-per-worker=2"],
+    ],
+)
+def test_maxfail_stops_before_entire_backlog_runs(testdir, cli_args):
+    """
+    Test that with --maxfail=1 and many pending tests, the backlog must not
+    all run.
+
+    The precise number that does run is nondeterministic (it depends on how
+    many workers/threads were concurrently past `queue.get()` at the moment
+    the master drained the queue). This test only asserts the important
+    invariant: fewer than the full backlog ran.
+    """
+    num_tests = 20
+    testdir.makepyfile(_create_test_module_content(num_tests))
+    result = testdir.runpytest("--maxfail=1", *cli_args)
+
+    # Failed exit code expected because at least one test failed.
+    assert result.ret == 1
+
+    outcomes = result.parseoutcomes()
+    failed = outcomes.get("failed", 0)
+    passed = outcomes.get("passed", 0)
+
+    # At least one test ran and failed (that"s what tripped --maxfail).
+    assert failed >= 1
+    # But the drain must have prevented the full backlog from executing.
+    assert failed + passed < num_tests, (
+        f"Expected early stop to drop some pending tests, but "
+        f"{failed + passed} of {num_tests} ran ({cli_args=})"
+    )
+
+
+@pytest.mark.parametrize(
+    "cli_args",
+    [
+        ["--workers=2"],
+        ["--tests-per-worker=2"],
+        ["--workers=2", "--tests-per-worker=2"],
+    ],
+)
+def test_no_maxfail_runs_entire_backlog(testdir, cli_args):
+    """
+    Test that without `--maxfail`, the drain must not fire. Every failing test
+    in the queue must still be executed.
+    """
+    num_tests = 20
+    testdir.makepyfile(_create_test_module_content(num_tests))
+    result = testdir.runpytest(*cli_args)
+
+    assert result.ret == 1
+    result.assert_outcomes(failed=num_tests)
+
+
+@pytest.mark.parametrize(
+    "cli_args",
+    [
+        ["--workers=2"],
+        ["--tests-per-worker=2"],
+        ["--workers=2", "--tests-per-worker=2"],
+    ],
+)
+def test_maxfail_not_tripped_when_all_pass(testdir, cli_args):
+    """
+    Test that passing tests do not trip any stop flag.
+    """
+    num_tests = 20
+    testdir.makepyfile(_create_test_module_content(num_tests, tests_pass=True))
+    result = testdir.runpytest("--maxfail=1", *cli_args)
+
+    assert result.ret == 0
+    result.assert_outcomes(passed=num_tests)


### PR DESCRIPTION
A `pytest` session supports the `shouldstop` and `shouldfail` flags. These signal to `pytest` that the session should stop early. However, the `pytest-parallel` plugin ignored these flags, meaning core functionality (like `--maxfail`) was effectively broken when running tests in parallel.

This commit fixes this by adding a new method to the plugin, `_check_for_stop`, which runs inside the master's response-processing thread. This already drives `pytest`'s own `pytest_runtest_logreport` hook chain, which is what flips the `shouldstop` and `shouldfail` flags in the first place. The flags are checked immediately afterwards, and on the first transition from False to True, the plugin drains any pending tests from the shared queue. The 'stop' sentinels that were pushed at startup are left in place (and re-enqueued if drained), so any worker currently blocked on `queue.get()` will next receive a sentinel and exit via its existing shutdown path. Workers that are already past `queue.get()` (i.e. running a test) finish that test before looping back to pick up the sentinel, which matches `pytest`'s normal semantics. This also ensures tests are allowed to complete and tear down gracefully.

The drain is idempotent via a `_stop_requested` flag. Later reports that arrive after the first stop are no-ops. Queue accounting is preserved by calling `task_done()` on every item pulled, and `ConnectionRefusedError` is swallowed in the same shape as the rest of this plugin.

A new unit test module has been added which covers this new behaviour, using the `--maxfail` flag to trigger the stop.

The new functionality has been documented in the `README`.